### PR TITLE
fixes deprecation with extension dependency

### DIFF
--- a/DependencyInjection/LexikMaintenanceExtension.php
+++ b/DependencyInjection/LexikMaintenanceExtension.php
@@ -5,7 +5,7 @@ namespace Lexik\Bundle\MaintenanceBundle\DependencyInjection;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**


### PR DESCRIPTION
Fixes following Symfony 7.1 deprecation:

```text
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Lexik\Bundle\MaintenanceBundle\DependencyInjection\LexikMaintenanceExtension".
```